### PR TITLE
Flow expiration based on packet time in pcap rather than server time.

### DIFF
--- a/rustiflow/src/main.rs
+++ b/rustiflow/src/main.rs
@@ -968,8 +968,13 @@ fn process_packet_ipv4<T>(
     });
 
     let end = entry.update_flow(&features, &ts, ts_date, fwd);
-    if let Some(flow) = end {
-        export(&flow);
+    if end.is_some() {
+        let flow = entry.value();
+        if *NO_CONTAMINANT_FEATURES.lock().unwrap().deref() {
+            export(&flow.dump_without_contamination());
+        } else {
+            export(&flow.dump());
+        }
         drop(entry);
         flow_map.remove(&flow_id);
     }
@@ -1027,8 +1032,13 @@ fn process_packet_ipv6<T>(
     });
 
     let end = entry.update_flow(&features, &ts, ts_date, fwd);
-    if let Some(flow) = end {
-        export(&flow);
+    if end.is_some() {
+        let flow = entry.value();
+        if *NO_CONTAMINANT_FEATURES.lock().unwrap().deref() {
+            export(&flow.dump_without_contamination());
+        } else {
+            export(&flow.dump());
+        }
         drop(entry);
         flow_map.remove(&flow_id);
     }


### PR DESCRIPTION
Fixed by checking on each packet if flows need to be expired based on timestamps in the pcap. We might change this later for performance.