### PR TITLE
Feature/add config file instead of cli

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,13 @@
+[config]
+features = "CIC"         # FlowType can be one of: Basic, CIC, CIDDS, Nfstream, NTL, Custom
+active_timeout = 3600    # Maximum time a flow is allowed to last in seconds
+idle_timeout = 120       # Maximum time with no packets for a flow in seconds
+early_export = 300       # Optional, print interval for open flows in seconds
+threads = 4              # Number of threads to use for processing packets, optional
+
+[output]
+output = "Csv"                       # OutputMethodType can be one of: Print, Csv
+export_path = "output.csv"  # Path for output if method is Csv
+header = true                        # Whether to export the feature header
+drop_contaminant_features = false    # Whether to drop contaminant features
+

--- a/rustiflow/Cargo.toml
+++ b/rustiflow/Cargo.toml
@@ -27,12 +27,13 @@ tokio = { version = "1.25", features = [
 bytes = "1"
 env_logger = "0.11"
 chrono = "0.4.34"
-dashmap = "5.5.3"
+dashmap = "6.0.1"
 pcap = "2.0.0"
-pnet = "0.34.0"
+pnet = "0.35.0"
 lazy_static = "1.4.0"
 libc = "0.2.153"
 num_cpus = "1.14"
+confy = "0.6.1"
 
 [[bin]]
 name = "rustiflow"


### PR DESCRIPTION
Added the ability to use a config file instead of all the cli commands, when a config file is given, these values are used otherwise the cli parameters need to be filled in. When a config file path is given that does not exist, this will then created with default values.