### PR TITLE
Enhancement/59 tcp termination logic

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-/// BasicFeaturesIpv4 is a struct collection all ipv4 traffic data and is 24 bytes in size.
+/// BasicFeaturesIpv4 is a struct collection all ipv4 traffic data and is 32 bytes in size.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct EbpfEventIpv4 {
@@ -52,7 +52,7 @@ impl EbpfEventIpv4 {
 #[cfg(feature = "user")]
 unsafe impl aya::Pod for EbpfEventIpv4 {}
 
-/// BasicFeaturesIpv6 is a struct collection all ipv6 traffic data and is 48 bytes in size.
+/// BasicFeaturesIpv6 is a struct collection all ipv6 traffic data and is 64 bytes in size.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct EbpfEventIpv6 {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -13,6 +13,7 @@ pub struct EbpfEventIpv4 {
     pub combined_flags: u8,
     pub protocol: u8,
     pub header_length: u8,
+    pub sequence_number: u32,
     pub _padding: [u8; 3], // Explicit padding to match the size of the struct in the eBPF program
 }
 
@@ -28,6 +29,7 @@ impl EbpfEventIpv4 {
         combined_flags: u8,
         protocol: u8,
         header_length: u8,
+        sequence_number: u32,
     ) -> Self {
         EbpfEventIpv4 {
             ipv4_destination,
@@ -40,6 +42,7 @@ impl EbpfEventIpv4 {
             combined_flags,
             protocol,
             header_length,
+            sequence_number,
             _padding: [0; 3],
         }
     }
@@ -62,7 +65,8 @@ pub struct EbpfEventIpv6 {
     pub combined_flags: u8,
     pub protocol: u8,
     pub header_length: u8,
-    _padding: [u8; 3], // Explicit padding to match the size of the struct in the eBPF program
+    pub sequence_number: u32,
+    _padding: [u8; 15], // Explicit padding to match the size of the struct in the eBPF program
 }
 
 impl EbpfEventIpv6 {
@@ -77,6 +81,7 @@ impl EbpfEventIpv6 {
         combined_flags: u8,
         protocol: u8,
         header_length: u8,
+        sequence_number: u32,
     ) -> Self {
         EbpfEventIpv6 {
             ipv6_destination,
@@ -89,7 +94,8 @@ impl EbpfEventIpv6 {
             combined_flags,
             protocol,
             header_length,
-            _padding: [0; 3],
+            sequence_number,
+            _padding: [0; 15],
         }
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -14,7 +14,7 @@ pub struct EbpfEventIpv4 {
     pub protocol: u8,
     pub header_length: u8,
     pub sequence_number: u32,
-    pub _padding: [u8; 3], // Explicit padding to match the size of the struct in the eBPF program
+    pub sequence_number_ack: u32,
 }
 
 impl EbpfEventIpv4 {
@@ -30,6 +30,7 @@ impl EbpfEventIpv4 {
         protocol: u8,
         header_length: u8,
         sequence_number: u32,
+        sequence_number_ack: u32,
     ) -> Self {
         EbpfEventIpv4 {
             ipv4_destination,
@@ -43,7 +44,7 @@ impl EbpfEventIpv4 {
             protocol,
             header_length,
             sequence_number,
-            _padding: [0; 3],
+            sequence_number_ack,
         }
     }
 }
@@ -66,7 +67,7 @@ pub struct EbpfEventIpv6 {
     pub protocol: u8,
     pub header_length: u8,
     pub sequence_number: u32,
-    _padding: [u8; 15], // Explicit padding to match the size of the struct in the eBPF program
+    pub sequence_number_ack: u32,
 }
 
 impl EbpfEventIpv6 {
@@ -82,6 +83,7 @@ impl EbpfEventIpv6 {
         protocol: u8,
         header_length: u8,
         sequence_number: u32,
+        sequence_number_ack: u32,
     ) -> Self {
         EbpfEventIpv6 {
             ipv6_destination,
@@ -95,7 +97,7 @@ impl EbpfEventIpv6 {
             protocol,
             header_length,
             sequence_number,
-            _padding: [0; 15],
+            sequence_number_ack,
         }
     }
 }

--- a/ebpf-ipv4/src/main.rs
+++ b/ebpf-ipv4/src/main.rs
@@ -95,6 +95,7 @@ impl PacketInfo {
             self.protocol,
             header.header_length(),
             header.sequence_number(),
+            header.sequence_number_ack(),
         )
     }
 }
@@ -106,6 +107,7 @@ trait NetworkHeader {
     fn combined_flags(&self) -> u8;
     fn header_length(&self) -> u8;
     fn sequence_number(&self) -> u32;
+    fn sequence_number_ack(&self) -> u32;
 }
 
 impl NetworkHeader for TcpHdr {
@@ -134,6 +136,9 @@ impl NetworkHeader for TcpHdr {
     fn sequence_number(&self) -> u32 {
         self.seq
     }
+    fn sequence_number_ack(&self) -> u32 {
+        self.ack_seq
+    }
 }
 
 impl NetworkHeader for UdpHdr {
@@ -155,6 +160,9 @@ impl NetworkHeader for UdpHdr {
     fn sequence_number(&self) -> u32 {
         0
     }
+    fn sequence_number_ack(&self) -> u32 {
+        0
+    }
 }
 
 impl NetworkHeader for IcmpHdr {
@@ -174,6 +182,9 @@ impl NetworkHeader for IcmpHdr {
         IcmpHdr::LEN as u8
     }
     fn sequence_number(&self) -> u32 {
+        0
+    }
+    fn sequence_number_ack(&self) -> u32 {
         0
     }
 }

--- a/ebpf-ipv4/src/main.rs
+++ b/ebpf-ipv4/src/main.rs
@@ -94,6 +94,7 @@ impl PacketInfo {
             header.combined_flags(),
             self.protocol,
             header.header_length(),
+            header.sequence_number(),
         )
     }
 }
@@ -104,6 +105,7 @@ trait NetworkHeader {
     fn window_size(&self) -> u16;
     fn combined_flags(&self) -> u8;
     fn header_length(&self) -> u8;
+    fn sequence_number(&self) -> u32;
 }
 
 impl NetworkHeader for TcpHdr {
@@ -129,6 +131,9 @@ impl NetworkHeader for TcpHdr {
     fn header_length(&self) -> u8 {
         TcpHdr::LEN as u8
     }
+    fn sequence_number(&self) -> u32 {
+        self.seq
+    }
 }
 
 impl NetworkHeader for UdpHdr {
@@ -147,6 +152,9 @@ impl NetworkHeader for UdpHdr {
     fn header_length(&self) -> u8 {
         UdpHdr::LEN as u8
     }
+    fn sequence_number(&self) -> u32 {
+        0
+    }
 }
 
 impl NetworkHeader for IcmpHdr {
@@ -164,5 +172,8 @@ impl NetworkHeader for IcmpHdr {
     }
     fn header_length(&self) -> u8 {
         IcmpHdr::LEN as u8
+    }
+    fn sequence_number(&self) -> u32 {
+        0
     }
 }

--- a/ebpf-ipv6/src/main.rs
+++ b/ebpf-ipv6/src/main.rs
@@ -95,6 +95,7 @@ impl PacketInfo {
             self.protocol,
             header.header_length(),
             header.sequence_number(),
+            header.sequence_number_ack(),
         )
     }
 }
@@ -106,6 +107,7 @@ trait NetworkHeader {
     fn combined_flags(&self) -> u8;
     fn header_length(&self) -> u8;
     fn sequence_number(&self) -> u32;
+    fn sequence_number_ack(&self) -> u32;
 }
 
 impl NetworkHeader for TcpHdr {
@@ -134,6 +136,9 @@ impl NetworkHeader for TcpHdr {
     fn sequence_number(&self) -> u32 {
         self.seq
     }
+    fn sequence_number_ack(&self) -> u32 {
+        self.ack_seq
+    }
 }
 
 impl NetworkHeader for UdpHdr {
@@ -155,6 +160,9 @@ impl NetworkHeader for UdpHdr {
     fn sequence_number(&self) -> u32 {
         0
     }
+    fn sequence_number_ack(&self) -> u32 {
+        0
+    }
 }
 
 impl NetworkHeader for IcmpHdr {
@@ -174,6 +182,9 @@ impl NetworkHeader for IcmpHdr {
         IcmpHdr::LEN as u8
     }
     fn sequence_number(&self) -> u32 {
+        0
+    }
+    fn sequence_number_ack(&self) -> u32 {
         0
     }
 }

--- a/ebpf-ipv6/src/main.rs
+++ b/ebpf-ipv6/src/main.rs
@@ -94,6 +94,7 @@ impl PacketInfo {
             header.combined_flags(),
             self.protocol,
             header.header_length(),
+            header.sequence_number(),
         )
     }
 }
@@ -104,6 +105,7 @@ trait NetworkHeader {
     fn window_size(&self) -> u16;
     fn combined_flags(&self) -> u8;
     fn header_length(&self) -> u8;
+    fn sequence_number(&self) -> u32;
 }
 
 impl NetworkHeader for TcpHdr {
@@ -129,6 +131,9 @@ impl NetworkHeader for TcpHdr {
     fn header_length(&self) -> u8 {
         TcpHdr::LEN as u8
     }
+    fn sequence_number(&self) -> u32 {
+        self.seq
+    }
 }
 
 impl NetworkHeader for UdpHdr {
@@ -147,6 +152,9 @@ impl NetworkHeader for UdpHdr {
     fn header_length(&self) -> u8 {
         UdpHdr::LEN as u8
     }
+    fn sequence_number(&self) -> u32 {
+        0
+    }
 }
 
 impl NetworkHeader for IcmpHdr {
@@ -164,5 +172,8 @@ impl NetworkHeader for IcmpHdr {
     }
     fn header_length(&self) -> u8 {
         IcmpHdr::LEN as u8
+    }
+    fn sequence_number(&self) -> u32 {
+        0
     }
 }

--- a/rustiflow/src/flows/basic_flow.rs
+++ b/rustiflow/src/flows/basic_flow.rs
@@ -1,7 +1,6 @@
 use std::net::IpAddr;
 
 use chrono::{DateTime, Utc};
-use log::debug;
 
 use crate::packet_features::PacketFeatures;
 
@@ -97,20 +96,16 @@ impl BasicFlow {
             if forward {
                 self.state_fwd = FlowState::FinSent;
                 self.expected_ack_seq_bwd = Some(packet.sequence_number + packet.data_length as u32 + 1);
-                debug!("Flow {} FIN sent in forward direction with sequence number {} and payload length {}", self.flow_key, packet.sequence_number, packet.data_length);
             } else {
                 self.state_bwd = FlowState::FinSent;
                 self.expected_ack_seq_fwd = Some(packet.sequence_number + packet.data_length as u32 + 1);
-                debug!("Flow {} FIN sent in backward direction with sequence number {} and payload length {}", self.flow_key, packet.sequence_number, packet.data_length);
             }
         }
 
         if self.state_bwd == FlowState::FinSent && forward && Some(packet.sequence_number_ack) == self.expected_ack_seq_fwd {
             self.state_bwd = FlowState::FinAcked;
-            debug!("Flow {} FIN acknowledged in backward direction with sequence number {}", self.flow_key, packet.sequence_number_ack);
         } else if self.state_fwd == FlowState::FinSent && !forward && Some(packet.sequence_number_ack) == self.expected_ack_seq_bwd {
             self.state_fwd = FlowState::FinAcked;
-            debug!("Flow {} FIN acknowledged in forward direction with sequence number {}", self.flow_key, packet.sequence_number_ack);
         }
 
         // Return true if both sides are finished and acknowledged the termination
@@ -181,7 +176,6 @@ impl Flow for BasicFlow {
 
         if self.is_tcp_finished(packet, fwd) {
             self.flow_end_of_flow_ack = 1;
-            debug!("Flow {} terminated", self.flow_key);
         }
 
         if fwd {

--- a/rustiflow/src/output.rs
+++ b/rustiflow/src/output.rs
@@ -52,7 +52,6 @@ where
     }
 
     pub fn write_flow(&mut self, flow: T) -> std::io::Result<()> {
-        debug!("Writing flow to output");
         let flow_str = if self.skip_contaminant_features {
             flow.dump_without_contamination()
         } else {

--- a/rustiflow/src/packet_features.rs
+++ b/rustiflow/src/packet_features.rs
@@ -35,6 +35,7 @@ pub struct PacketFeatures {
     pub length: u16,
     pub window_size: u16,
     pub sequence_number: u32,
+    pub sequence_number_ack: u32,
 }
 
 impl PacketFeatures {
@@ -60,6 +61,7 @@ impl PacketFeatures {
             length: event.length,
             window_size: event.window_size,
             sequence_number: event.sequence_number,
+            sequence_number_ack: event.sequence_number_ack,
         }
     }
 
@@ -85,6 +87,7 @@ impl PacketFeatures {
             length: event.length,
             window_size: event.window_size,
             sequence_number: event.sequence_number,
+            sequence_number_ack: event.sequence_number_ack,
         }
     }
 
@@ -207,6 +210,7 @@ fn extract_packet_features_transport(
                 length: total_length,
                 window_size: tcp_packet.get_window(),
                 sequence_number: tcp_packet.get_sequence(),
+                sequence_number_ack: tcp_packet.get_acknowledgement(),
             })
         }
         IpNextHeaderProtocols::Udp => {
@@ -231,6 +235,7 @@ fn extract_packet_features_transport(
                 length: total_length,
                 window_size: 0, // No window size for UDP
                 sequence_number: 0, // No sequence number for UDP
+                sequence_number_ack: 0, // No sequence number ACK for UDP
             })
         }
         IpNextHeaderProtocols::Icmp | IpNextHeaderProtocols::Icmpv6 => {
@@ -255,6 +260,7 @@ fn extract_packet_features_transport(
                 length: total_length,
                 window_size: 0, // No window size for ICMP
                 sequence_number: 0, // No sequence number for ICMP
+                sequence_number_ack: 0, // No sequence number ACK for ICMP
             })
         }
         _ => {

--- a/rustiflow/src/packet_features.rs
+++ b/rustiflow/src/packet_features.rs
@@ -34,6 +34,7 @@ pub struct PacketFeatures {
     pub header_length: u8,
     pub length: u16,
     pub window_size: u16,
+    pub sequence_number: u32,
 }
 
 impl PacketFeatures {
@@ -58,6 +59,7 @@ impl PacketFeatures {
             header_length: event.header_length,
             length: event.length,
             window_size: event.window_size,
+            sequence_number: event.sequence_number,
         }
     }
 
@@ -82,6 +84,7 @@ impl PacketFeatures {
             header_length: event.header_length,
             length: event.length,
             window_size: event.window_size,
+            sequence_number: event.sequence_number,
         }
     }
 
@@ -203,6 +206,7 @@ fn extract_packet_features_transport(
                 header_length: (tcp_packet.get_data_offset() * 4) as u8,
                 length: total_length,
                 window_size: tcp_packet.get_window(),
+                sequence_number: tcp_packet.get_sequence(),
             })
         }
         IpNextHeaderProtocols::Udp => {
@@ -226,6 +230,7 @@ fn extract_packet_features_transport(
                 header_length: 8, // Fixed header size for UDP
                 length: total_length,
                 window_size: 0, // No window size for UDP
+                sequence_number: 0, // No sequence number for UDP
             })
         }
         IpNextHeaderProtocols::Icmp | IpNextHeaderProtocols::Icmpv6 => {
@@ -249,6 +254,7 @@ fn extract_packet_features_transport(
                 header_length: 8, // Fixed header size for ICMP
                 length: total_length,
                 window_size: 0, // No window size for ICMP
+                sequence_number: 0, // No sequence number for ICMP
             })
         }
         _ => {


### PR DESCRIPTION
Updated the tcp termination with sequence numbers.

This is shortly tested. It should be tested more intensely to make sure that a flow is terminated at the correct moment. Better to do this in a protected environment.

closes #59 