### PR TITLE
:heavy_plus_sign: Update aya dependency

### DIFF
--- a/ebpf-ipv4/Cargo.toml
+++ b/ebpf-ipv4/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aya-ebpf = "0.1.0"
-aya-log-ebpf = "0.1.0"
+aya-ebpf = "0.1.1"
+aya-log-ebpf = "0.1.1"
 common = { path = "../common" }
 network-types = "0.0.7"
 

--- a/ebpf-ipv6/Cargo.toml
+++ b/ebpf-ipv6/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aya-ebpf = "0.1.0"
-aya-log-ebpf = "0.1.0"
+aya-ebpf = "0.1.1"
+aya-log-ebpf = "0.1.1"
 common = { path = "../common" }
 network-types = "0.0.7"
 

--- a/rustiflow/Cargo.toml
+++ b/rustiflow/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 clap = { version = "4.5.0", features = ["derive"] }
 csv = "1.3.0"
 serde = { version = "1.0.196", features = ["derive"] }
-aya = { version = "0.12.0", features = ["async_tokio"] }
+aya = { version = "0.13.0", features = ["async_tokio"] }
 aya-log = "0.2.0"
 common = { path = "../common", features = ["user"] }
 anyhow = "1"


### PR DESCRIPTION
Update aya to version 0.13.0 and the logger also to fix confilicts.

Some clarification: The tool chain of Aya has new versions. For some reason even with having the versions pinned at a specific version, cargo had some dependency issues. Also for Aya 0.13.0 you need a rustc version of 1.81.0, you can update this by running `rustup update` on your local machine.