### PR TITLE
:bug: Fix missing padding

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -16,6 +16,7 @@ pub struct EbpfEventIpv4 {
     pub header_length: u8,
     pub sequence_number: u32,
     pub sequence_number_ack: u32,
+    pub _padding: [u8; 3],
 }
 
 impl EbpfEventIpv4 {
@@ -46,6 +47,7 @@ impl EbpfEventIpv4 {
             header_length,
             sequence_number,
             sequence_number_ack,
+            _padding: [0; 3],
         }
     }
 }
@@ -69,6 +71,7 @@ pub struct EbpfEventIpv6 {
     pub header_length: u8,
     pub sequence_number: u32,
     pub sequence_number_ack: u32,
+    pub _padding: [u8; 11],
 }
 
 impl EbpfEventIpv6 {
@@ -99,6 +102,7 @@ impl EbpfEventIpv6 {
             header_length,
             sequence_number,
             sequence_number_ack,
+            _padding: [0; 11],
         }
     }
 }

--- a/ebpf-ipv6/src/main.rs
+++ b/ebpf-ipv6/src/main.rs
@@ -28,7 +28,7 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 static DROPPED_PACKETS: PerCpuArray<u64> = PerCpuArray::with_max_entries(1, 0);
 
 #[map]
-static EVENTS_IPV6: RingBuf = RingBuf::with_byte_size(1024 * 1024 * 10, 0); // 10 MB
+static EVENTS_IPV6: RingBuf = RingBuf::with_byte_size(1024 * 1024 * 10 * 2, 0); // 10 MB
 
 #[classifier]
 pub fn tc_flow_track(ctx: TcContext) -> i32 {


### PR DESCRIPTION
Added the padding again, as this is needed for ubuntu 20.04 systems. (Byte alignment that is not going correctly if this is not 32 bytes or 64 bytes.)