### PR TITLE
:sparkles: Add new feature icmp type to ebpf programs

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+pub use network_types::{icmp::IcmpHdr, tcp::TcpHdr, udp::UdpHdr};
+
 /// BasicFeaturesIpv4 is a struct collection all ipv4 traffic data and is 32 bytes in size.
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -16,7 +18,8 @@ pub struct EbpfEventIpv4 {
     pub header_length: u8,
     pub sequence_number: u32,
     pub sequence_number_ack: u32,
-    pub _padding: [u8; 3],
+    pub icmp_type: u8,
+    pub _padding: [u8; 2],
 }
 
 impl EbpfEventIpv4 {
@@ -33,6 +36,7 @@ impl EbpfEventIpv4 {
         header_length: u8,
         sequence_number: u32,
         sequence_number_ack: u32,
+        icmp_type: u8,
     ) -> Self {
         EbpfEventIpv4 {
             ipv4_destination,
@@ -47,7 +51,8 @@ impl EbpfEventIpv4 {
             header_length,
             sequence_number,
             sequence_number_ack,
-            _padding: [0; 3],
+            icmp_type,
+            _padding: [0; 2],
         }
     }
 }
@@ -71,7 +76,8 @@ pub struct EbpfEventIpv6 {
     pub header_length: u8,
     pub sequence_number: u32,
     pub sequence_number_ack: u32,
-    pub _padding: [u8; 11],
+    pub icmp_type: u8,
+    pub _padding: [u8; 10],
 }
 
 impl EbpfEventIpv6 {
@@ -88,6 +94,7 @@ impl EbpfEventIpv6 {
         header_length: u8,
         sequence_number: u32,
         sequence_number_ack: u32,
+        icmp_type: u8,
     ) -> Self {
         EbpfEventIpv6 {
             ipv6_destination,
@@ -102,10 +109,110 @@ impl EbpfEventIpv6 {
             header_length,
             sequence_number,
             sequence_number_ack,
-            _padding: [0; 11],
+            icmp_type,
+            _padding: [0; 10],
         }
     }
 }
 
 #[cfg(feature = "user")]
 unsafe impl aya::Pod for EbpfEventIpv6 {}
+
+pub trait NetworkHeader {
+    fn source_port(&self) -> u16;
+    fn destination_port(&self) -> u16;
+    fn window_size(&self) -> u16;
+    fn combined_flags(&self) -> u8;
+    fn header_length(&self) -> u8;
+    fn sequence_number(&self) -> u32;
+    fn sequence_number_ack(&self) -> u32;
+    fn icmp_type(&self) -> u8;
+}
+
+impl NetworkHeader for TcpHdr {
+    fn source_port(&self) -> u16 {
+        self.source
+    }
+    fn destination_port(&self) -> u16 {
+        self.dest
+    }
+    fn window_size(&self) -> u16 {
+        self.window as u16
+    }
+    fn combined_flags(&self) -> u8 {
+        ((self.fin() as u8) << 0)
+            | ((self.syn() as u8) << 1)
+            | ((self.rst() as u8) << 2)
+            | ((self.psh() as u8) << 3)
+            | ((self.ack() as u8) << 4)
+            | ((self.urg() as u8) << 5)
+            | ((self.ece() as u8) << 6)
+            | ((self.cwr() as u8) << 7)
+    }
+    fn header_length(&self) -> u8 {
+        TcpHdr::LEN as u8
+    }
+    fn sequence_number(&self) -> u32 {
+        self.seq
+    }
+    fn sequence_number_ack(&self) -> u32 {
+        self.ack_seq
+    }
+    fn icmp_type(&self) -> u8 {
+        0
+    }
+}
+
+impl NetworkHeader for UdpHdr {
+    fn source_port(&self) -> u16 {
+        self.source
+    }
+    fn destination_port(&self) -> u16 {
+        self.dest
+    }
+    fn window_size(&self) -> u16 {
+        0
+    }
+    fn combined_flags(&self) -> u8 {
+        0
+    }
+    fn header_length(&self) -> u8 {
+        UdpHdr::LEN as u8
+    }
+    fn sequence_number(&self) -> u32 {
+        0
+    }
+    fn sequence_number_ack(&self) -> u32 {
+        0
+    }
+    fn icmp_type(&self) -> u8 {
+        0
+    }
+}
+
+impl NetworkHeader for IcmpHdr {
+    fn source_port(&self) -> u16 {
+        0
+    }
+    fn destination_port(&self) -> u16 {
+        0
+    }
+    fn window_size(&self) -> u16 {
+        0
+    }
+    fn combined_flags(&self) -> u8 {
+        0
+    }
+    fn header_length(&self) -> u8 {
+        IcmpHdr::LEN as u8
+    }
+    fn sequence_number(&self) -> u32 {
+        0
+    }
+    fn sequence_number_ack(&self) -> u32 {
+        0
+    }
+    fn icmp_type(&self) -> u8 {
+        self.type_
+    }
+}

--- a/ebpf-ipv4/src/main.rs
+++ b/ebpf-ipv4/src/main.rs
@@ -5,18 +5,19 @@
 use aya_ebpf::{
     bindings::TC_ACT_PIPE,
     macros::{classifier, map},
-    maps::{RingBuf, PerCpuArray},
+    maps::{PerCpuArray, RingBuf},
     programs::TcContext,
 };
 use aya_log_ebpf::error;
 
 use common::EbpfEventIpv4;
+use common::IcmpHdr;
+use common::NetworkHeader;
+use common::TcpHdr;
+use common::UdpHdr;
 use network_types::{
     eth::{EthHdr, EtherType},
     ip::{IpProto, Ipv4Hdr},
-    tcp::TcpHdr,
-    udp::UdpHdr,
-    icmp::IcmpHdr,
 };
 
 #[panic_handler]
@@ -48,36 +49,50 @@ fn process_packet(ctx: &TcContext) -> Result<i32, ()> {
     let packet_info = PacketInfo::new(&ipv4hdr, ctx.data_end() - ctx.data())?;
 
     match ipv4hdr.proto {
-        IpProto::Tcp => process_transport_packet::<TcpHdr>(ctx, packet_info),
-        IpProto::Udp => process_transport_packet::<UdpHdr>(ctx, packet_info),
-        IpProto::Icmp => process_transport_packet::<IcmpHdr>(ctx, packet_info),
+        IpProto::Tcp => process_transport_packet::<TcpHdr>(ctx, &packet_info),
+        IpProto::Udp => process_transport_packet::<UdpHdr>(ctx, &packet_info),
+        IpProto::Icmp => process_icmp_packet(ctx, &packet_info, &ipv4hdr),
         _ => Ok(TC_ACT_PIPE),
+    }
+}
+
+fn process_icmp_packet(
+    ctx: &TcContext,
+    packet_info: &PacketInfo,
+    ipv4hdr: &Ipv4Hdr,
+) -> Result<i32, ()> {
+    // Calculate actual IPv4 header length
+    let ip_header_length = (ipv4hdr.ihl() as usize) * 4;
+    let icmp_hdr_offset = EthHdr::LEN + ip_header_length;
+    let icmph = ctx.load::<IcmpHdr>(icmp_hdr_offset).map_err(|_| ())?;
+
+    let event = packet_info.to_packet_log(&icmph);
+    submit_ipv4_event(ctx, event);
+    Ok(TC_ACT_PIPE)
+}
+
+#[inline(always)]
+fn submit_ipv4_event(ctx: &TcContext, event: EbpfEventIpv4) {
+    if let Some(mut entry) = EVENTS_IPV4.reserve::<EbpfEventIpv4>(0) {
+        *entry = core::mem::MaybeUninit::new(event);
+        entry.submit(0);
+    } else {
+        if let Some(counter) = DROPPED_PACKETS.get_ptr_mut(0) {
+            unsafe { *counter += 1 };
+        }
+        error!(ctx, "Failed to reserve entry in ring buffer.");
     }
 }
 
 fn process_transport_packet<T: NetworkHeader>(
     ctx: &TcContext,
-    packet_info: PacketInfo,
+    packet_info: &PacketInfo,
 ) -> Result<i32, ()> {
-    let hdr = ctx
-        .load::<T>(EthHdr::LEN + Ipv4Hdr::LEN)
-        .map_err(|_| ())?;
+    let hdr = ctx.load::<T>(EthHdr::LEN + Ipv4Hdr::LEN).map_err(|_| ())?;
     let packet_log = packet_info.to_packet_log(&hdr);
 
-    // Reserve memory in the ring buffer for the event
-    if let Some(mut entry) = EVENTS_IPV4.reserve::<EbpfEventIpv4>(0) {
-        // Use MaybeUninit to write the packet_log data into the reserved memory
-        *entry = core::mem::MaybeUninit::new(packet_log);
-        // Submit the entry to make it visible to userspace
-        entry.submit(0);
-    } else {
-        // Handle the case where the ring buffer is full
-        if let Some(counter) = DROPPED_PACKETS.get_ptr_mut(0) {
-            unsafe { *counter += 1; }
-        }
-        error!(ctx, "Failed to reserve entry in ring buffer, buffer might be full.");
-    }
-    
+    submit_ipv4_event(ctx, packet_log);
+
     Ok(TC_ACT_PIPE)
 }
 
@@ -97,7 +112,7 @@ impl PacketInfo {
             protocol: ipv4hdr.proto as u8,
         })
     }
-    
+
     #[inline(always)]
     fn to_packet_log<T: NetworkHeader>(&self, header: &T) -> EbpfEventIpv4 {
         EbpfEventIpv4::new(
@@ -113,95 +128,7 @@ impl PacketInfo {
             header.header_length(),
             header.sequence_number(),
             header.sequence_number_ack(),
+            header.icmp_type(),
         )
-    }
-}
-
-trait NetworkHeader {
-    fn source_port(&self) -> u16;
-    fn destination_port(&self) -> u16;
-    fn window_size(&self) -> u16;
-    fn combined_flags(&self) -> u8;
-    fn header_length(&self) -> u8;
-    fn sequence_number(&self) -> u32;
-    fn sequence_number_ack(&self) -> u32;
-}
-
-impl NetworkHeader for TcpHdr {
-    fn source_port(&self) -> u16 {
-        self.source
-    }
-    fn destination_port(&self) -> u16 {
-        self.dest
-    }
-    fn window_size(&self) -> u16 {
-        self.window as u16
-    }
-    fn combined_flags(&self) -> u8 {
-        ((self.fin() as u8) << 0)
-            | ((self.syn() as u8) << 1)
-            | ((self.rst() as u8) << 2)
-            | ((self.psh() as u8) << 3)
-            | ((self.ack() as u8) << 4)
-            | ((self.urg() as u8) << 5)
-            | ((self.ece() as u8) << 6)
-            | ((self.cwr() as u8) << 7)
-    }
-    fn header_length(&self) -> u8 {
-        TcpHdr::LEN as u8
-    }
-    fn sequence_number(&self) -> u32 {
-        self.seq
-    }
-    fn sequence_number_ack(&self) -> u32 {
-        self.ack_seq
-    }
-}
-
-impl NetworkHeader for UdpHdr {
-    fn source_port(&self) -> u16 {
-        self.source
-    }
-    fn destination_port(&self) -> u16 {
-        self.dest
-    }
-    fn window_size(&self) -> u16 {
-        0
-    }
-    fn combined_flags(&self) -> u8 {
-        0
-    }
-    fn header_length(&self) -> u8 {
-        UdpHdr::LEN as u8
-    }
-    fn sequence_number(&self) -> u32 {
-        0
-    }
-    fn sequence_number_ack(&self) -> u32 {
-        0
-    }
-}
-
-impl NetworkHeader for IcmpHdr {
-    fn source_port(&self) -> u16 {
-        0
-    }
-    fn destination_port(&self) -> u16 {
-        0
-    }
-    fn window_size(&self) -> u16 {
-        0
-    }
-    fn combined_flags(&self) -> u8 {
-        0
-    }
-    fn header_length(&self) -> u8 {
-        IcmpHdr::LEN as u8
-    }
-    fn sequence_number(&self) -> u32 {
-        0
-    }
-    fn sequence_number_ack(&self) -> u32 {
-        0
     }
 }

--- a/ebpf-ipv6/src/main.rs
+++ b/ebpf-ipv6/src/main.rs
@@ -29,7 +29,7 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 static DROPPED_PACKETS: PerCpuArray<u64> = PerCpuArray::with_max_entries(1, 0);
 
 #[map]
-static EVENTS_IPV6: RingBuf = RingBuf::with_byte_size(1024 * 1024 * 10 * 2, 0); // 10 MB
+static EVENTS_IPV6: RingBuf = RingBuf::with_byte_size(1024 * 1024 * 10 * 2, 0); // 20 MB
 
 #[classifier]
 pub fn tc_flow_track(ctx: TcContext) -> i32 {
@@ -39,31 +39,87 @@ pub fn tc_flow_track(ctx: TcContext) -> i32 {
     }
 }
 
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct Ipv6ExtensionHdr {
+    pub next_hdr: IpProto,
+    pub hdr_ext_len: u8,
+    // The rest is variable-length, but for the first 2 bytes, this is enough
+}
+
+const MAX_EXT_HEADERS: usize = 8; // Arbitrary safe limit
+
+fn is_extension_header(proto: IpProto) -> bool {
+    matches!(
+        proto,
+        IpProto::HopOpt     // 0   Hop-by-Hop
+            | IpProto::Ipv6Route    // 43  Routing
+            | IpProto::Ipv6Frag   // 44  Fragment
+            | IpProto::Esp       // 50  ESP
+            | IpProto::Ah        // 51  Auth
+            | IpProto::Ipv6Opts // 60 Destination Options
+            | IpProto::MobilityHeader    // 135 Mobility
+            | IpProto::Hip         // 139 HIP
+            | IpProto::Shim6 // 140 Shim6
+    )
+}
+
+fn skip_ipv6_ext_headers(ctx: &TcContext, start_offset: usize) -> Result<(IpProto, usize), ()> {
+    // Load the base IPv6 header
+    let ipv6hdr = ctx.load::<Ipv6Hdr>(start_offset).map_err(|_| ())?;
+
+    // Current offset: skip the fixed 40-byte IPv6 header
+    let mut offset = start_offset + Ipv6Hdr::LEN;
+    let mut next_hdr = ipv6hdr.next_hdr;
+
+    // Unrolled loop using a fixed number of iterations
+    for _ in 0..MAX_EXT_HEADERS {
+        if !is_extension_header(next_hdr) {
+            break;
+        }
+
+        // Load the extension header
+        let ext_hdr = ctx.load::<Ipv6ExtensionHdr>(offset).map_err(|_| ())?;
+
+        // Compute the total length of this extension header in bytes
+        let ext_len_bytes = (ext_hdr.hdr_ext_len as usize + 1) * 8;
+
+        offset += ext_len_bytes;
+        next_hdr = ext_hdr.next_hdr;
+    }
+
+    Ok((next_hdr, offset))
+}
+
 fn process_packet(ctx: &TcContext) -> Result<i32, ()> {
     let ether_type = ctx.load::<EthHdr>(0).map_err(|_| ())?.ether_type;
     if ether_type != EtherType::Ipv6 {
         return Ok(TC_ACT_PIPE);
     }
 
-    let ipv6hdr = ctx.load::<Ipv6Hdr>(EthHdr::LEN).map_err(|_| ())?;
-    let packet_info = PacketInfo::new(&ipv6hdr, ctx.data_end() - ctx.data())?;
+    // 1) Skip over IPv6 extension headers to find the real upper-layer protocol and offset
+    let (final_proto, offset_after_ext) = skip_ipv6_ext_headers(ctx, EthHdr::LEN)?;
 
-    match ipv6hdr.next_hdr {
-        IpProto::Tcp => process_transport_packet::<TcpHdr>(ctx, &packet_info),
-        IpProto::Udp => process_transport_packet::<UdpHdr>(ctx, &packet_info),
-        IpProto::Icmp => process_icmp_packet(ctx, &packet_info),
+    // 2) Build packet_info for IPv6
+    let ipv6hdr = ctx.load::<Ipv6Hdr>(EthHdr::LEN).map_err(|_| ())?;
+    let packet_info = PacketInfo::new(&ipv6hdr, ctx.data_end() - ctx.data(), final_proto)?;
+
+    // 3) Dispatch on the final protocol
+    match final_proto {
+        IpProto::Tcp => {
+            // For TCP, load `TcpHdr` at `offset_after_ext`
+            process_transport_packet::<TcpHdr>(ctx, &packet_info, offset_after_ext)
+        }
+        IpProto::Udp => {
+            // For UDP, load `UdpHdr` at `offset_after_ext`
+            process_transport_packet::<UdpHdr>(ctx, &packet_info, offset_after_ext)
+        }
+        IpProto::Ipv6Icmp => {
+            // For ICMPv6, load Icmpv6 at `offset_after_ext`
+            process_transport_packet::<IcmpHdr>(ctx, &packet_info, offset_after_ext)
+        }
         _ => Ok(TC_ACT_PIPE),
     }
-}
-
-fn process_icmp_packet(ctx: &TcContext, packet_info: &PacketInfo) -> Result<i32, ()> {
-    // Calculate actual IPv4 header length
-    let icmp_hdr_offset = EthHdr::LEN + Ipv6Hdr::LEN;
-    let icmph = ctx.load::<IcmpHdr>(icmp_hdr_offset).map_err(|_| ())?;
-
-    let event = packet_info.to_packet_log(&icmph);
-    submit_ipv6_event(ctx, event);
-    Ok(TC_ACT_PIPE)
 }
 
 #[inline(always)]
@@ -82,8 +138,9 @@ fn submit_ipv6_event(ctx: &TcContext, event: EbpfEventIpv6) {
 fn process_transport_packet<T: NetworkHeader>(
     ctx: &TcContext,
     packet_info: &PacketInfo,
+    transport_offset: usize,
 ) -> Result<i32, ()> {
-    let hdr = ctx.load::<T>(EthHdr::LEN + Ipv6Hdr::LEN).map_err(|_| ())?;
+    let hdr = ctx.load::<T>(transport_offset).map_err(|_| ())?;
     let packet_log = packet_info.to_packet_log(&hdr);
 
     submit_ipv6_event(ctx, packet_log);
@@ -99,12 +156,12 @@ struct PacketInfo {
 }
 
 impl PacketInfo {
-    fn new(ipv6hdr: &Ipv6Hdr, data_length: usize) -> Result<Self, ()> {
+    fn new(ipv6hdr: &Ipv6Hdr, data_length: usize, protocol: IpProto) -> Result<Self, ()> {
         Ok(Self {
             ipv6_source: u128::from_be_bytes(unsafe { ipv6hdr.src_addr.in6_u.u6_addr8 }),
             ipv6_destination: u128::from_be_bytes(unsafe { ipv6hdr.dst_addr.in6_u.u6_addr8 }),
             data_length: data_length as u16,
-            protocol: ipv6hdr.next_hdr as u8,
+            protocol: protocol as u8,
         })
     }
 

--- a/ebpf-ipv6/src/main.rs
+++ b/ebpf-ipv6/src/main.rs
@@ -10,11 +10,7 @@ use aya_ebpf::{
 };
 use aya_log_ebpf::error;
 
-use common::EbpfEventIpv6;
-use common::IcmpHdr;
-use common::NetworkHeader;
-use common::TcpHdr;
-use common::UdpHdr;
+use common::{EbpfEventIpv6, IcmpHdr, NetworkHeader, TcpHdr, UdpHdr};
 use network_types::{
     eth::{EthHdr, EtherType},
     ip::{IpProto, Ipv6Hdr},
@@ -106,16 +102,9 @@ fn process_packet(ctx: &TcContext) -> Result<i32, ()> {
 
     // 3) Dispatch on the final protocol
     match final_proto {
-        IpProto::Tcp => {
-            // For TCP, load `TcpHdr` at `offset_after_ext`
-            process_transport_packet::<TcpHdr>(ctx, &packet_info, offset_after_ext)
-        }
-        IpProto::Udp => {
-            // For UDP, load `UdpHdr` at `offset_after_ext`
-            process_transport_packet::<UdpHdr>(ctx, &packet_info, offset_after_ext)
-        }
+        IpProto::Tcp => process_transport_packet::<TcpHdr>(ctx, &packet_info, offset_after_ext),
+        IpProto::Udp => process_transport_packet::<UdpHdr>(ctx, &packet_info, offset_after_ext),
         IpProto::Ipv6Icmp => {
-            // For ICMPv6, load Icmpv6 at `offset_after_ext`
             process_transport_packet::<IcmpHdr>(ctx, &packet_info, offset_after_ext)
         }
         _ => Ok(TC_ACT_PIPE),


### PR DESCRIPTION
Ipv4 works as intended, the ipv6 version needs some more testing as this ipv6hdr doesn't have the `ihl()` funtion.